### PR TITLE
Minor bug fix. Typo I think

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ class ATP {
                 if(d.res){
                     data.push(d.res)
                 }
-                if(d.error){ err = d.error; qr = false; }
+                if(d.error){ error = d.error; qr = false; }
                 if(!d.next){ qr = false; }
             }
             return resolve({error: error, results: data})


### PR DESCRIPTION
'err' is not defined but 'error' is defined on line 22. When line 28 is trying to assign d.error to 'err' it fails and it crashes the calling application.

Changed 'err' to 'error' to match line 28 assignment to line 22 declaration and it functions as expected. The calling application gets an appropriate error message in the result instead of crashing.